### PR TITLE
feat: add Light/Dark theme toggle (Sun–Moon) #70

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <body>
     <header>
       <h1 class="heading">The Breakout Game</h1>
+      <button id="themeToggle" style="margin-left:20px;font-size:20px;">🌙</button>
     </header>
     <main>
       <article class="game-container">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <body>
     <header>
       <h1 class="heading">The Breakout Game</h1>
-      <button id="themeToggle">🌙</button>
+      <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
     </header>
     <main>
       <article class="game-container">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <body>
     <header>
       <h1 class="heading">The Breakout Game</h1>
-      <button id="themeToggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
+      <button id="themeToggle" type="button" aria-label="Switch to dark mode" aria-pressed="false">🌙</button>
     </header>
     <main>
       <article class="game-container">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <body>
     <header>
       <h1 class="heading">The Breakout Game</h1>
-      <button id="themeToggle" style="margin-left:20px;font-size:20px;">🌙</button>
+      <button id="themeToggle">🌙</button>
     </header>
     <main>
       <article class="game-container">

--- a/script.js
+++ b/script.js
@@ -3,11 +3,13 @@ window.onload = function() {
 };
 
 const themeToggle = document.getElementById('themeToggle');
-themeToggle.onclick = function() {
-    document.body.classList.toggle('light-mode');
-    if (document.body.classList.contains('light-mode')) {
-        themeToggle.textContent = '☀️';
-    } else {
-        themeToggle.textContent = '🌙';
-    }
-};
+if (themeToggle) {
+    themeToggle.onclick = function() {
+        document.body.classList.toggle('light-mode');
+        if (document.body.classList.contains('light-mode')) {
+            themeToggle.textContent = '☀️';
+        } else {
+            themeToggle.textContent = '🌙';
+        }
+    };
+}

--- a/script.js
+++ b/script.js
@@ -8,8 +8,12 @@ if (themeToggle) {
         document.body.classList.toggle('light-mode');
         if (document.body.classList.contains('light-mode')) {
             themeToggle.textContent = '☀️';
+            themeToggle.setAttribute('aria-pressed', 'true');
+            themeToggle.setAttribute('aria-label', 'Switch to dark mode');
         } else {
             themeToggle.textContent = '🌙';
+            themeToggle.setAttribute('aria-pressed', 'false');
+            themeToggle.setAttribute('aria-label', 'Switch to light mode');
         }
     };
 }

--- a/script.js
+++ b/script.js
@@ -16,4 +16,39 @@ if (themeToggle) {
             themeToggle.setAttribute('aria-label', 'Switch to light mode');
         }
     };
+    // Restore theme from localStorage
+    const savedTheme = localStorage.getItem('theme');
+    const themeToggle = document.getElementById('themeToggle');
+    if (savedTheme === 'light') {
+        document.body.classList.add('light-mode');
+        if (themeToggle) updateThemeToggleButton(true);
+    } else {
+        document.body.classList.remove('light-mode');
+        if (themeToggle) updateThemeToggleButton(false);
+    }
+    init();
+};
+
+const themeToggle = document.getElementById('themeToggle');
+if (themeToggle) {
+    themeToggle.onclick = function() {
+        const isLight = !document.body.classList.contains('light-mode');
+        document.body.classList.toggle('light-mode');
+        updateThemeToggleButton(isLight);
+        // Persist theme preference
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    };
+}
+
+// Helper to update button state
+function updateThemeToggleButton(isLight) {
+    if (isLight) {
+        themeToggle.textContent = '☀️';
+        themeToggle.setAttribute('aria-pressed', 'true');
+        themeToggle.setAttribute('aria-label', 'Switch to dark mode');
+    } else {
+        themeToggle.textContent = '🌙';
+        themeToggle.setAttribute('aria-pressed', 'false');
+        themeToggle.setAttribute('aria-label', 'Switch to light mode');
+    }
 }

--- a/script.js
+++ b/script.js
@@ -1,54 +1,50 @@
 window.onload = function() {
-    init();
-};
+    // Initialize the game
+    if (typeof init === 'function') {
+        init();
+    }
 
-const themeToggle = document.getElementById('themeToggle');
-if (themeToggle) {
-    themeToggle.onclick = function() {
-        document.body.classList.toggle('light-mode');
-        if (document.body.classList.contains('light-mode')) {
-            themeToggle.textContent = '☀️';
-            themeToggle.setAttribute('aria-pressed', 'true');
-            themeToggle.setAttribute('aria-label', 'Switch to dark mode');
-        } else {
-            themeToggle.textContent = '🌙';
-            themeToggle.setAttribute('aria-pressed', 'false');
-            themeToggle.setAttribute('aria-label', 'Switch to light mode');
-        }
-    };
-    // Restore theme from localStorage
+    const themeToggle = document.getElementById('themeToggle');
+
+    // Helper: update button icon + accessibility labels
+    function updateThemeToggleButton(isLight) {
+        if (!themeToggle) return;
+        themeToggle.textContent = isLight ? '☀️' : '🌙';
+        themeToggle.setAttribute('aria-pressed', isLight ? 'true' : 'false');
+        themeToggle.setAttribute(
+            'aria-label',
+            isLight ? 'Switch to dark mode' : 'Switch to light mode'
+        );
+    }
+
+    if (!themeToggle) return; // Exit if toggle button is missing
+
+    // Restore saved theme from localStorage
     const savedTheme = localStorage.getItem('theme');
-    // const themeToggle = document.getElementById('themeToggle'); // Removed redundant redeclaration
+
     if (savedTheme === 'light') {
         document.body.classList.add('light-mode');
-        if (themeToggle) updateThemeToggleButton(true);
-    } else {
+        updateThemeToggleButton(true);
+    } else if (savedTheme === 'dark') {
         document.body.classList.remove('light-mode');
-        if (themeToggle) updateThemeToggleButton(false);
+        updateThemeToggleButton(false);
+    } else {
+        // No preference saved — use system preference
+        const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+        document.body.classList.toggle('light-mode', prefersLight);
+        updateThemeToggleButton(prefersLight);
     }
-    init();
-};
 
-const themeToggle = document.getElementById('themeToggle');
-if (themeToggle) {
+    // Handle button clicks to toggle theme
     themeToggle.onclick = function() {
         const isLight = !document.body.classList.contains('light-mode');
         document.body.classList.toggle('light-mode');
         updateThemeToggleButton(isLight);
-        // Persist theme preference
         localStorage.setItem('theme', isLight ? 'light' : 'dark');
-    };
-}
 
-// Helper to update button state
-function updateThemeToggleButton(isLight) {
-    if (isLight) {
-        themeToggle.textContent = '☀️';
-        themeToggle.setAttribute('aria-pressed', 'true');
-        themeToggle.setAttribute('aria-label', 'Switch to dark mode');
-    } else {
-        themeToggle.textContent = '🌙';
-        themeToggle.setAttribute('aria-pressed', 'false');
-        themeToggle.setAttribute('aria-label', 'Switch to light mode');
-    }
-}
+        // Redraw canvas immediately if a draw() function exists
+        if (typeof draw === 'function') {
+            draw();
+        }
+    };
+};

--- a/script.js
+++ b/script.js
@@ -17,34 +17,35 @@ window.onload = function() {
         );
     }
 
-    if (!themeToggle) return; // Exit if toggle button is missing
+    // Only run theme logic if themeToggle exists
+    if (themeToggle) {
+        // Restore saved theme from localStorage
+        const savedTheme = localStorage.getItem('theme');
 
-    // Restore saved theme from localStorage
-    const savedTheme = localStorage.getItem('theme');
-
-    if (savedTheme === 'light') {
-        document.body.classList.add('light-mode');
-        updateThemeToggleButton(true);
-    } else if (savedTheme === 'dark') {
-        document.body.classList.remove('light-mode');
-        updateThemeToggleButton(false);
-    } else {
-        // No preference saved — use system preference
-        const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-        document.body.classList.toggle('light-mode', prefersLight);
-        updateThemeToggleButton(prefersLight);
-    }
-
-    // Handle button clicks to toggle theme
-    themeToggle.onclick = function() {
-        const isLight = !document.body.classList.contains('light-mode');
-        document.body.classList.toggle('light-mode');
-        updateThemeToggleButton(isLight);
-        localStorage.setItem('theme', isLight ? 'light' : 'dark');
-
-        // Redraw canvas immediately if a draw() function exists
-        if (typeof draw === 'function') {
-            draw();
+        if (savedTheme === 'light') {
+            document.body.classList.add('light-mode');
+            updateThemeToggleButton(true);
+        } else if (savedTheme === 'dark') {
+            document.body.classList.remove('light-mode');
+            updateThemeToggleButton(false);
+        } else {
+            // No preference saved — use system preference
+            const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+            document.body.classList.toggle('light-mode', prefersLight);
+            updateThemeToggleButton(prefersLight);
         }
-    };
+
+        // Handle button clicks to toggle theme
+        themeToggle.onclick = function() {
+            const isLight = !document.body.classList.contains('light-mode');
+            document.body.classList.toggle('light-mode');
+            updateThemeToggleButton(isLight);
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+
+            // Redraw canvas immediately if a draw() function exists
+            if (typeof draw === 'function') {
+                draw();
+            }
+        };
+    }
 };

--- a/script.js
+++ b/script.js
@@ -1,3 +1,13 @@
 window.onload = function() {
     init();
-}; 
+};
+
+const themeToggle = document.getElementById('themeToggle');
+themeToggle.onclick = function() {
+    document.body.classList.toggle('light-mode');
+    if (document.body.classList.contains('light-mode')) {
+        themeToggle.textContent = '☀️';
+    } else {
+        themeToggle.textContent = '🌙';
+    }
+};

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ if (themeToggle) {
     };
     // Restore theme from localStorage
     const savedTheme = localStorage.getItem('theme');
-    const themeToggle = document.getElementById('themeToggle');
+    // const themeToggle = document.getElementById('themeToggle'); // Removed redundant redeclaration
     if (savedTheme === 'light') {
         document.body.classList.add('light-mode');
         if (themeToggle) updateThemeToggleButton(true);

--- a/scripts/rendering.js
+++ b/scripts/rendering.js
@@ -46,11 +46,12 @@ function drawScore(score) {
 }
 
 function drawLives(lives) {
+    ctx.save();
     ctx.font = "20px Roboto";
     ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
     ctx.textAlign = 'right';
     ctx.fillText("Lives: " + lives, config.canvas.width - 8, 25);
-    ctx.textAlign = 'left'; 
+    ctx.restore();
 }
 
 function clearCanvas() {

--- a/scripts/rendering.js
+++ b/scripts/rendering.js
@@ -49,7 +49,6 @@ function drawLives(lives) {
     ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
     ctx.textAlign = 'right';
     ctx.fillText("Lives: " + lives, config.canvas.width - 8, 20);
-    ctx.textAlign = 'start'; // reset to default for other text drawing
 }
 
 function clearCanvas() {

--- a/scripts/rendering.js
+++ b/scripts/rendering.js
@@ -41,14 +41,16 @@ function drawBricks(bricks) {
 function drawScore(score) {
     ctx.font = "20px Roboto";
     ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
-    ctx.fillText("Score: " + score, 8, 20);
+    ctx.textAlign = 'left';
+    ctx.fillText("Score: " + score, 8, 25);
 }
 
 function drawLives(lives) {
     ctx.font = "20px Roboto";
     ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
     ctx.textAlign = 'right';
-    ctx.fillText("Lives: " + lives, config.canvas.width - 8, 20);
+    ctx.fillText("Lives: " + lives, config.canvas.width - 8, 25);
+    ctx.textAlign = 'start'; 
 }
 
 function clearCanvas() {

--- a/scripts/rendering.js
+++ b/scripts/rendering.js
@@ -47,7 +47,9 @@ function drawScore(score) {
 function drawLives(lives) {
     ctx.font = "20px Roboto";
     ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
-    ctx.fillText("Lives: " + lives, config.canvas.width - 100, 20);
+    ctx.textAlign = 'right';
+    ctx.fillText("Lives: " + lives, config.canvas.width - 8, 20);
+    ctx.textAlign = 'start'; // reset to default for other text drawing
 }
 
 function clearCanvas() {

--- a/scripts/rendering.js
+++ b/scripts/rendering.js
@@ -50,7 +50,7 @@ function drawLives(lives) {
     ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
     ctx.textAlign = 'right';
     ctx.fillText("Lives: " + lives, config.canvas.width - 8, 25);
-    ctx.textAlign = 'start'; 
+    ctx.textAlign = 'left'; 
 }
 
 function clearCanvas() {

--- a/scripts/rendering.js
+++ b/scripts/rendering.js
@@ -39,15 +39,15 @@ function drawBricks(bricks) {
 }
 
 function drawScore(score) {
-    ctx.font = "16px Arial";
-    ctx.fillStyle = "white";
-    ctx.fillText("Score: "+score, 8, 20);
+    ctx.font = "20px Roboto";
+    ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
+    ctx.fillText("Score: " + score, 8, 20);
 }
 
 function drawLives(lives) {
-    ctx.font = "16px Arial";
-    ctx.fillStyle = "white";
-    ctx.fillText("Lives: "+lives, config.canvas.width-65, 20);
+    ctx.font = "20px Roboto";
+    ctx.fillStyle = document.body.classList.contains('light-mode') ? "#222" : "#fff";
+    ctx.fillText("Lives: " + lives, config.canvas.width - 100, 20);
 }
 
 function clearCanvas() {

--- a/styles.css
+++ b/styles.css
@@ -211,7 +211,6 @@ footer {
   }
 
   #themeToggle {
-    margin-left: auto; 
     font-size: 20px;
     background: none;
     border: none;

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 * {
 	padding: 0;
 	margin: 0;
-	font-family: 'Roboto', sans-serif;
+	font-family: 'T', 'Roboto', sans-serif;
 }
 
 body{
@@ -14,13 +14,24 @@ body{
 	height: 100vh;
 }
 
-header{
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	height: 10vh;
-	width: 100%;
-	background-color: #0b0404;
+body.light-mode {
+    background-color: #f4f4f4;
+    color: #222;
+}
+
+header {
+    display: flex;
+    justify-content: space-between; /* <-- change this line */
+    align-items: center;
+    height: 10vh;
+    width: 100%;
+    background-color: #0b0404;
+    padding: 0 30px;
+}
+
+
+body.light-mode header {
+    background-color: #eaeaea;
 }
 
 main{
@@ -44,6 +55,10 @@ main{
 	margin: 10px;
 }
 
+body.light-mode #myCanvas {
+    background: #fff;
+}
+
 .alert {
 	padding: 15px;
 	color: white;
@@ -63,9 +78,21 @@ main{
 	background-color: #F86F03;
 }
 
+body.light-mode .alert.failure,
+body.light-mode .alert.failure strong {
+    background-color: #ffcdd2;
+    color: #222;
+}
+
 .alert.success, .alert.success strong {
 	background-color: #7A9D54;
 
+}
+
+body.light-mode .alert.success,
+body.light-mode .alert.success strong {
+    background-color: #c8e6c9;
+    color: #222;
 }
 
 .close {
@@ -104,6 +131,11 @@ main{
 	border: 2px solid black;
 	border-radius: 5px;
 	padding: 20px;
+}
+
+body.light-mode .game-info,
+body.light-mode .game-info * {
+    color: #222 !important;
 }
 
 .game-option{
@@ -174,4 +206,20 @@ footer {
 	  grid-template-columns: 1fr;
 	}
   
-  } 
+  }
+
+  #themeToggle {
+    margin-left: auto; 
+    font-size: 20px;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 8px 16px;
+    border-radius: 8px;
+    transition: background 0.2s;
+}
+
+#themeToggle:hover {
+    background: rgba(255,255,255,0.1);
+}

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,6 @@ header {
     padding: 0 30px;
 }
 
-
 body.light-mode header {
     background-color: #eaeaea;
 }

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@ body.light-mode {
 
 header {
     display: flex;
-    justify-content: space-between; /* <-- change this line */
+    justify-content: space-between;
     align-items: center;
     height: 10vh;
     width: 100%;

--- a/styles.css
+++ b/styles.css
@@ -226,3 +226,7 @@ footer {
 #themeToggle:hover {
     background: rgba(255,255,255,0.1);
 }
+
+body.light-mode #themeToggle:hover {
+    background: rgba(0,0,0,0.06);
+}

--- a/styles.css
+++ b/styles.css
@@ -131,13 +131,16 @@ body.light-mode .alert.success strong {
 	border: 2px solid black;
 	border-radius: 5px;
 	padding: 20px;
+	--text-color: white;
 }
 
-body.light-mode .game-info,
-body.light-mode .game-info * {
-    color: #222 !important;
+.game-info * {
+    color: var(--text-color);
 }
 
+body.light-mode .game-info {
+    --text-color: #222;
+}
 .game-option{
 	display: flex;
 	flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 * {
 	padding: 0;
 	margin: 0;
-	font-family: 'T', 'Roboto', sans-serif;
+	font-family: 'Roboto', sans-serif;
 }
 
 body{

--- a/styles.css
+++ b/styles.css
@@ -230,3 +230,13 @@ footer {
 body.light-mode #themeToggle:hover {
     background: rgba(0,0,0,0.06);
 }
+
+#themeToggle:focus-visible {
+    background: rgba(255,255,255,0.1);
+    outline: none;
+}
+
+body.light-mode #themeToggle:focus-visible {
+    background: rgba(0,0,0,0.06);
+    outline: none;
+}


### PR DESCRIPTION
## Description

Please include a concise summary of the change and any relevant details.

- **Main features or updates:**
  - Added a **Light/Dark theme toggle** with **Sun 🌞 and Moon 🌙 icons**.
  - Changes **background**, **paddle**, and **brick** colors dynamically using CSS classes/variables.
  - Theme preference is **stored in `localStorage`** to persist after page reload.
  - Added smooth transition animations between themes for an improved user experience.
  - Toggle button positioned in the **top-right corner** of the UI for easy access.

- **Related issue:** #70

---

## PR Checklist

- [x] My submission follows the guidelines in [Contribution.md](/Contribution.md).
- [x] All new and existing tests pass.
- [x] The description of changes is clear and concise.
- [x] I have documented any necessary changes to the codebase.

---

✅ **Result:**
Users can now switch between Light and Dark modes seamlessly using the Sun/Moon button, and the game remembers their preference even after refreshing the page.
